### PR TITLE
Add missing prop in the field

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -11,6 +11,7 @@
                 ref="telInputField"
                 :id="field.attribute"
                 :autoFormat="propValue('autoFormat', true)"
+                :mode="propValue('mode', 'auto')"
                 :customValidate="propValue('customValidate', false)"
                 :defaultCountry="propValue('defaultCountry', '')"
                 :disabled="propValue('disabled', false)"


### PR DESCRIPTION
Add the mode option in vue-tel-input. The mode can be already set in the field using the `->withMode('...')` but it's not actually mapped to the frontend